### PR TITLE
able to support local-xy-scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # CHANGELOG
 
 ## Unreleased changes
-* セットアップデータのassanファイルを出力しないように変更
+* SpriteStudio6対応
+  * セットアップデータのassanファイルを出力しないように変更
+  * X/Yローカルスケールサポート
 
 ## 2.5.2
 * 内部モジュールの更新

--- a/spec/SpriteStudioSpec.js
+++ b/spec/SpriteStudioSpec.js
@@ -660,5 +660,21 @@ describe("SpriteStudio.", function () {
 				}
 			});
 		});
+
+		it("can get LSCX and LSCY", function() {
+			contents.forEach(function(content) {
+				if ("SpriteStudioAnimePack" in content) {
+					SS.loadFromSSAE(proj, content, {outputUserData: true, labelAsUserData: true});
+
+					const anime = findAnimation(proj, "anime_1");
+					expect(anime.curveTies.stick_body.curves.some(function(curve) {
+						return curve.attribute === 'lsx';
+					})).toBeTruthy();
+					expect(anime.curveTies.stick_body.curves.some(function(curve) {
+						return curve.attribute === 'lsy';
+					})).toBeTruthy();
+				}
+			});
+		});
 	});
 });

--- a/spec/project/SampleV6/SampleV6.sspj
+++ b/spec/project/SampleV6/SampleV6.sspj
@@ -156,7 +156,7 @@
 	<lastAnimeFile>stickman.ssae</lastAnimeFile>
 	<lastAnimeName>anime_1</lastAnimeName>
 	<lastCellMapFile>stickman.ssce</lastCellMapFile>
-	<lastCell>stick_arm_leg</lastCell>
-	<lastPart>root</lastPart>
+	<lastCell>stick_body</lastCell>
+	<lastPart>stick_body</lastPart>
 	<setupmode>0</setupmode>
 </SpriteStudioProject>

--- a/spec/project/SampleV6/stickman.ssae
+++ b/spec/project/SampleV6/stickman.ssae
@@ -438,6 +438,22 @@
 								<value>0</value>
 							</key>
 						</attribute>
+						<attribute tag="LSCX">
+							<key time="0" ipType="linear">
+								<value>1.40000009536743</value>
+							</key>
+							<key time="10" ipType="linear">
+								<value>0.699999928474426</value>
+							</key>
+						</attribute>
+						<attribute tag="LSCY">
+							<key time="0" ipType="linear">
+								<value>1.40000009536743</value>
+							</key>
+							<key time="10" ipType="linear">
+								<value>0.799999952316284</value>
+							</key>
+						</attribute>
 						<attribute tag="PRIO">
 							<key time="0" ipType="linear">
 								<value>0</value>

--- a/src/SpriteStudio.ts
+++ b/src/SpriteStudio.ts
@@ -25,6 +25,8 @@ const ssAttr2asaAttr: any = {
 	ROTZ: "rz",
 	SCLX: "sx",
 	SCLY: "sy",
+	LSCX: "lsx",
+	LSCY: "lsy",
 	ALPH: "alpha",
 	CELL: "cv",
 	PVTX: "pvtx",


### PR DESCRIPTION
### 概要
* akashic-animationでローカルX/Yスケール属性をサポートできるようにするために、SS6で設定されたローカルXスケール属性とローカルYスケール属性の値をファイル出力できるにしました

### やったこと
* ローカルX/Yスケール属性をそれぞれlsx、lsyというキー名でファイル出力されるようにした
* ローカルX/Yスケール属性の値が取得できることを検証する単体テストの追加