### PR TITLE
Bump version to 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased changes
+## 2.5.2
 * SpriteStudio6対応
   * セットアップデータのassanファイルを出力しないように変更
   * X/Yローカルスケールサポート


### PR DESCRIPTION
package.jsonの更新( `version` の修正 )は以前のコミットですでに行っていたので、ここではCHANGELOG.mdのみ更新します。