### PR TITLE
Add a description for using by TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,20 @@ ss2asa.convert({
 });
 ```
 
+※ TypeScript で利用する場合、 `@akashic/akashic-engine` の型定義ファイルを `tsconfig.json` で指定する必要があります。
+
+```diff
+{
+  "compilerOptions": {
+    ...
+  },
++  "files": [
++    "node_modules/@akashic/akashic-engine/lib/main.d.ts"
++  ]
+  ...
+}
+```
+
 ## オプション
 * `projFileName: string` (required)
   * SpriteStudioのプロジェクトファイル


### PR DESCRIPTION
## このPullRequestが解決する内容
ss2asa の内部処理において `g` を参照している箇所があるため、このモジュールをTypeScriptで利用する場合の型定義の指定方法を README.md に追加します。