### PR TITLE
feat: support compact animation data format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased changes
+
+* ポーターを指定する -t, --porter オプションを追加
+  * aop を指定するとファイル容量が削減される
+* 未知のアトリビュートを無視する --ignore-unknown-attribute オプションを追加
+
 ## 2.8.0
 
 * SpriteStudioで利用される補間方法の一部をサポート

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # CHANGELOG
 
-## Unreleased changes
+## 2.9.0
 
 * ポーターを指定する -t, --porter オプションを追加
   * aop を指定するとファイル容量が削減される
 * 未知のアトリビュートを無視する --ignore-unknown-attribute オプションを追加
+* ポーターを検証する --debug-verify-porter オプションを追加
+  * デバッグ機能。通常これを利用することはない
 
 ## 2.8.0
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ asapjファイルと関連するファイルの一覧をasapjファイルのユ�
 
 現在は `aop` (Array Oriented Porter) を指定できます。`aop` を指定すると、ファイルサイズが削減されます。
 
-aop を適用したファイルを読み込むことができる Akashic Animation は 4.1.0 以降になります。
+aop を適用したファイルを読み込むことができる Akashic Animation は 4.2.0 以降になります。
 
 ### --ignore-unknown-attribute
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # ss2asa
+
 SpriteStudio形式のファイルををakashic-animation形式にコンバートするコマンドラインツール。
 
 ## インストール
 
 `ss2asa` は `Node.js` で動作します。以下のコマンドでインストールできます。
+
 ```sh
 $ npm install -g @akashic-extension/ss2asa
 ```
@@ -11,16 +13,17 @@ $ npm install -g @akashic-extension/ss2asa
 npx が利用できる環境では `ss2asa` を直接呼び出すこともできます。
 
 ```sh
-$ npx -p @akashic-extension/ss2asa ss2asa project-file.sspj
+npx -p @akashic-extension/ss2asa ss2asa project-file.sspj
 ```
 
 Akashic Engineの詳細な利用方法については、 [公式ページ](https://akashic-games.github.io/) を参照してください。
 
 ## 使い方
+
 SpriteStudioのプロジェクトファイルを渡してください。関連ファイル(ssae,ssce)を含めすべてコンバートします。
 
 ```sh
-$ ss2asa project-file.sspj
+ss2asa project-file.sspj
 ```
 
 出力されるファイルは次のように対応します。
@@ -32,16 +35,21 @@ $ ss2asa project-file.sspj
 | ssce          | asask         | スキンファイル                         |
 
 ## オプション
+
 ### -h, --help
+
 ヘルプを表示します。
 
 ### -V, --version
+
 バージョンを表示します。
 
 ### -o, --out-dir
+
 出力先ディレクトリを指定します。存在しない時、ディレクトリを作成します。
 
 ### -p, --add-prefix
+
 出力ファイルのファイル名に次の接頭辞を加えます。
 
 | ファイル形式  | 接頭辞        |
@@ -50,13 +58,15 @@ $ ss2asa project-file.sspj
 | asabn         | bn_           |
 | asaan         | an_           |
 | asask         | sk_           |
-
+| asaef         | ef_           |
 
 ### -l, --long-name
+
 asaanファイル名(アニメーション名が用いられる)の前にssaeファイル名が加わります。２つの間は`_`で区切られます。
 
 例: `ss2asa -l jobs.sspj`
-```
+
+```text
 input:
 jobs.sspj
 ├── fighter.ssae
@@ -78,9 +88,11 @@ healer_walk.asaan
 この時各アニメーションデータの持つnameプロパティはロングネーム化されたファイル名と同じものになります。開発者はロングネームでアニメーションを指定してください。
 
 ### -b, --bundle-all
+
 すべてのアセットデータをまとめてasapjファイルに出力します。
 
 例(contentsプロパティ内の関係のないものは省略):
+
 ```json
 {
     "version": "3.0.0",
@@ -113,24 +125,31 @@ healer_walk.asaan
 ```
 
 ### -d, --delete-hidden
+
 SpriteStudio上で目玉アイコンを用いて非表示にしたパーツとそのアニメーションを削除します。
 
 ### -P --set-prefix
+
 `-p` オプションで出力ファイル名に加わる接頭辞を指定します。asapj,asabn,asask,asaan形式それぞれについて、この並びでカンマ区切りで指定します。デフォルトは`pj_,bn_,sk_,an_`です。
 
 ### -v, --verbose
+
 実行時の出力に詳細情報を含めます。
 
 ### -u, --user-data
+
 ユーザデータを出力します。
 
 ### -L, --label-as-user-data
+
 ラベルをユーザデータ形式で出力します。`-u`オプションが有効である必要があります。ユーザデータキーフレームはルートボーンのアニメーションとして追加されます。プロパティ名は`label`です。
 
 ### -c, --combination-info
+
 ボーン、スキン、アニメーションの有効な組み合わせの情報をasapjファイルのユーザデータとして出力します。`contents.userData.combinationInfo`プロパティからアクセスできます。
 
 例(contentsプロパティ内の関係のないものは省略):
+
 ```json
 {
     "version": "2.0.0",
@@ -155,9 +174,11 @@ SpriteStudio上で目玉アイコンを用いて非表示にしたパーツと�
 ```
 
 ### -r, --related-file-info
+
 asapjファイルと関連するファイルの一覧をasapjファイルのユーザデータとして出力します。`contents.userData.relatedFileInfo`プロパティからアクセスできます。
 
 例(contentsプロパティ内の関係のないものは省略):
+
 ```json
 {
     "version": "2.0.0",
@@ -189,9 +210,23 @@ asapjファイルと関連するファイルの一覧をasapjファイルのユ�
 ```
 
 ### -s, --layout-size
+
 アニメーションのレイアウト情報を出力します。`contents.userData.layoutSizes`プロパティからアクセスできます。
 
+### --porter
+
+ポーターを指定します。ポーターは各種データをシリアライズする前に加工・変換するものです。
+
+現在は `aop` を指定できます。aopを指定すると、ファイルサイズが削減されます。
+
+aop を適用したファイルを読み込むことができる Akashic Engine は 4.1.0 以降になります。
+
+## --ignore-unknown-attribute
+
+Akashic Animation で利用できない属性を無視します。
+
 ## 使い方 (Node.js API)
+
 Node.js のモジュールとして呼び出すこともできます。
 
 ```javascript
@@ -219,6 +254,7 @@ ss2asa.convert({
 ```
 
 ## オプション
+
 * `projFileName: string` (required)
   * SpriteStudioのプロジェクトファイル
 * `outDir: string` (required)
@@ -247,7 +283,9 @@ ss2asa.convert({
   * アニメーションのレイアウト情報を出力するかどうか
 
 ## akashic-animationのサポートするアトリビュート
+
 以下のアトリビュートのアニメーションをサポートします。
+
 * 参照セル
 * X座標
 * Y座標
@@ -272,7 +310,9 @@ ss2asa.convert({
 * ユーザーデータ
 
 ## 補足
+
 ## キーフレームの外挿
+
 akashic-animationは再生するアニメーションの0フレーム目がキーフレームでない時、0フレーム目に初期値を与えます。初期値は属性により異なります（次の表参照）。
 
 | 属性                | 値         |
@@ -311,6 +351,7 @@ akashic-animationは再生するアニメーションの0フレーム目がキ�
 * 減速
 
 次の補間方法をサポートしていません。
+
 * イーズイン
 * イーズアウト
 * イーズインアウト
@@ -331,11 +372,14 @@ akashic-animationは再生するアニメーションの0フレーム目がキ�
 * イーズバックインアウト
 
 ## セルマップ参照イメージのアセット名に関する制限
+
 `ss2asa`はセルマップの参照するイメージのアセット名として、もとのイメージファイル名から拡張子を除いたものをasaskファイルに保存します。たとえば"stickman.png"のアセット名は"stickman"となります。
 もしgame.jsonで指定されるイメージアセット名がファイル名から拡張子を除いたものでない時、実行時エラーとなります(game.jsonの更新に`akashic-cli`を使用している限りそのような不整合は起こりません)。
 
 ## NULLパーツから出力される属性値に関する制限
+
 ss2asaはNULLパーツの持つ属性値の内、以下のもののみを出力します。
+
 * X, Y座標
 * Z回転
 * X, Yスケール
@@ -344,9 +388,11 @@ ss2asaはNULLパーツの持つ属性値の内、以下のもののみを出力�
 * ユーザデータ
 
 ## SpriteStudioの推奨環境設定
+
 akashic-animationはSpriteStudioの全機能をサポートしていません。サポートされない機能を誤って用いることを防ぐため、初期設定から編集可能な属性を選択することをお勧めします。
 
 ### 設定方法
+
 以下の手順はバージョン 5.5.1.5759 で確認しました。
 
 1. 環境設定 -> 一般設定 -> 新規プロジェクトのデフォルト設定 -> 一般 -> 互換性 を開き 再生対象のプラットフォームをカスタムにする
@@ -393,6 +439,7 @@ akashic-animationはSpriteStudioの全機能をサポートしていません。
 | 　 | インスタンス      |
 
 ## ライセンス
+
 本リポジトリは MIT License の元で公開されています。
 詳しくは [LICENSE](./LICENSE) をご覧ください。
 

--- a/README.md
+++ b/README.md
@@ -217,13 +217,17 @@ asapjファイルと関連するファイルの一覧をasapjファイルのユ�
 
 ポーターを指定します。ポーターは各種データをシリアライズする前に加工・変換するものです。
 
-現在は `aop` を指定できます。aopを指定すると、ファイルサイズが削減されます。
+現在は `aop` (Array Oriented Porter) を指定できます。`aop` を指定すると、ファイルサイズが削減されます。
 
 aop を適用したファイルを読み込むことができる Akashic Animation は 4.1.0 以降になります。
 
-## --ignore-unknown-attribute
+### --ignore-unknown-attribute
 
 Akashic Animation で利用できない属性を無視します。
+
+### --debug-verify-porter
+
+ポーターを検証するデバッグ機能です。通常使用することはありません。
 
 ## 使い方 (Node.js API)
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ asapjファイルと関連するファイルの一覧をasapjファイルのユ�
 
 現在は `aop` を指定できます。aopを指定すると、ファイルサイズが削減されます。
 
-aop を適用したファイルを読み込むことができる Akashic Engine は 4.1.0 以降になります。
+aop を適用したファイルを読み込むことができる Akashic Animation は 4.1.0 以降になります。
 
 ## --ignore-unknown-attribute
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
-        "@akashic-extension/akashic-animation": "file:../akashic-animation/akashic-extension-akashic-animation-4.1.0.tgz",
+        "@akashic-extension/akashic-animation": "^4.2.0",
         "@akashic/akashic-engine": "^3.18.1",
         "commander": "^12.1.0",
         "fs-extra": "^11.2.0",
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@akashic-extension/akashic-animation": {
-      "version": "4.1.0",
-      "resolved": "file:../akashic-animation/akashic-extension-akashic-animation-4.1.0.tgz",
-      "integrity": "sha512-XrvbmBjHx1qOvIU5pgr8IhRtcgyhzpfL+10YR3rkRRL7jRu8gqhKzkskrNdYd8xHI6HOvdIdFB42PrA1QgKUFg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@akashic-extension/akashic-animation/-/akashic-animation-4.2.0.tgz",
+      "integrity": "sha512-gxx792KeAB9oGN827SzaXCO0V6tNlv0sgZUdtRECku/XbZidvGCPVTRham2ln6bqI2ebGtN1Ctb/qvEEVH1EWA==",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-engine": "~3.4.3"
@@ -10020,8 +10020,9 @@
   },
   "dependencies": {
     "@akashic-extension/akashic-animation": {
-      "version": "file:../akashic-animation/akashic-extension-akashic-animation-4.1.0.tgz",
-      "integrity": "sha512-XrvbmBjHx1qOvIU5pgr8IhRtcgyhzpfL+10YR3rkRRL7jRu8gqhKzkskrNdYd8xHI6HOvdIdFB42PrA1QgKUFg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@akashic-extension/akashic-animation/-/akashic-animation-4.2.0.tgz",
+      "integrity": "sha512-gxx792KeAB9oGN827SzaXCO0V6tNlv0sgZUdtRECku/XbZidvGCPVTRham2ln6bqI2ebGtN1Ctb/qvEEVH1EWA==",
       "requires": {
         "@akashic/akashic-engine": "~3.4.3"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic-extension/ss2asa",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic-extension/ss2asa",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "@akashic-extension/akashic-animation": "^4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
-        "@akashic-extension/akashic-animation": "~3.2.0",
-        "@akashic/akashic-engine": "~2.6.2",
-        "commander": "^5.0.0",
-        "fs-extra": "^2.0.0",
-        "xml2js": "^0.4.15"
+        "@akashic-extension/akashic-animation": "file:../akashic-animation/akashic-extension-akashic-animation-4.1.0.tgz",
+        "@akashic/akashic-engine": "^3.18.1",
+        "commander": "^12.1.0",
+        "fs-extra": "^11.2.0",
+        "xml2js": "^0.6.2"
       },
       "bin": {
         "ss2asa": "bin/run"
@@ -22,9 +22,9 @@
         "@akashic/eslint-config": "^0.1.2",
         "@akashic/remark-preset-lint": "~0.1.1",
         "@types/commander": "2.12.0",
-        "@types/fs-extra": "5.0.2",
-        "@types/node": "~14.14.16",
-        "@types/xml2js": "~0.4.8",
+        "@types/fs-extra": "^11.0.4",
+        "@types/node": "^20.14.0",
+        "@types/xml2js": "^0.4.14",
         "@typescript-eslint/eslint-plugin": "^4.15.0",
         "del": "^2.2.2",
         "eslint": "^7.19.0",
@@ -33,26 +33,83 @@
         "jest": "~26.6.3",
         "remark-cli": "^9.0.0",
         "rimraf": "^3.0.2",
-        "typescript": "^3.9.7"
+        "typescript": "^5.5.4"
       }
     },
     "node_modules/@akashic-extension/akashic-animation": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@akashic-extension/akashic-animation/-/akashic-animation-3.2.1.tgz",
-      "integrity": "sha512-qbsv5B8iTNi08fUCAzvIbxWYLFTifeAFEz7VZnF2aaWoG6E4wzhVp0BC+2rz8wpHlrCtrZa/3Xq1D5PaY15v3g==",
+      "version": "4.1.0",
+      "resolved": "file:../akashic-animation/akashic-extension-akashic-animation-4.1.0.tgz",
+      "integrity": "sha512-XrvbmBjHx1qOvIU5pgr8IhRtcgyhzpfL+10YR3rkRRL7jRu8gqhKzkskrNdYd8xHI6HOvdIdFB42PrA1QgKUFg==",
+      "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-engine": "~2.0.0"
+        "@akashic/akashic-engine": "~3.4.3"
       }
     },
     "node_modules/@akashic-extension/akashic-animation/node_modules/@akashic/akashic-engine": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-2.0.3.tgz",
-      "integrity": "sha1-alMt5xpTZ+hpsWFFb2CokIkMgzU="
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.4.4.tgz",
+      "integrity": "sha512-458/BbaVeMn7qCl/woq8c4hfoxsTtuGeqqmitFwnug9lcdMvv3HSSdxqye1Gwr7ztW+71hGEeWypM02i6c3prA==",
+      "dependencies": {
+        "@akashic/game-configuration": "~1.4.0",
+        "@akashic/pdi-types": "~1.3.0",
+        "@akashic/playlog": "~3.1.0",
+        "@akashic/trigger": "~1.0.1"
+      }
     },
     "node_modules/@akashic/akashic-engine": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-2.6.6.tgz",
-      "integrity": "sha512-3TMGlwXIEVRXpx2n0Wle+UTW98yOeNLlP8htkb8ZpFGHg3hIKHUq8+rRl+01oj4ND11xaFVuizvfRg5htjO2Rw=="
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.18.1.tgz",
+      "integrity": "sha512-L27RN1MgG0lngDwjZ4Z8+GarmOh7UJKznfAgYKHpQt7RdoAaYmJ76tHlG1WCasiTVrwmggIP2Bqt8YMu9W1FBQ==",
+      "dependencies": {
+        "@akashic/game-configuration": "~2.2.0",
+        "@akashic/pdi-types": "^1.13.0",
+        "@akashic/playlog": "~3.3.0",
+        "@akashic/trigger": "~2.1.0"
+      }
+    },
+    "node_modules/@akashic/akashic-engine/node_modules/@akashic/amflow": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.3.0.tgz",
+      "integrity": "sha512-+dDBtwPfAOeslclGYYKF1yoGg+NiLnDHO3DVIGorkzSd9YLwf+LJGK4sQxRvltKBygmHmhaVrjP7de0PMA+c4Q==",
+      "dependencies": {
+        "@akashic/playlog": "~3.3.0"
+      }
+    },
+    "node_modules/@akashic/akashic-engine/node_modules/@akashic/game-configuration": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-2.2.0.tgz",
+      "integrity": "sha512-+sAREJpjwGxN2YhzID+ov1gx2xF5MXgEHdCMc1QnZvtRwj5A1TZZfHFM0+KxdpmJg1OT0LGmApZClZDgMDpqlg==",
+      "dependencies": {
+        "@akashic/pdi-types": "^1.11.1"
+      }
+    },
+    "node_modules/@akashic/akashic-engine/node_modules/@akashic/pdi-types": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@akashic/pdi-types/-/pdi-types-1.14.0.tgz",
+      "integrity": "sha512-QwCQHII8nNdO6nOc/x1MAyN6PGpzsSrhBpq+WYXlav3MbDxZEX9JGJEIbrNdAfEZMK5CJ5LCpkVvQxTOefnZwg==",
+      "dependencies": {
+        "@akashic/amflow": "~3.3.0",
+        "@akashic/playlog": "~3.3.0",
+        "@akashic/trigger": "~2.1.0"
+      }
+    },
+    "node_modules/@akashic/akashic-engine/node_modules/@akashic/playlog": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@akashic/playlog/-/playlog-3.3.0.tgz",
+      "integrity": "sha512-pqX31etu1H9DGvfAuW8w4TiUdcKUUoTBJQd6HF1OZWMDC2O6RSx8DTndYa4Eqr9wll+bs3aRJqUHcVdDJKWevw=="
+    },
+    "node_modules/@akashic/akashic-engine/node_modules/@akashic/trigger": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@akashic/trigger/-/trigger-2.1.0.tgz",
+      "integrity": "sha512-Ae+rhN6R2jnAwd4rZhXIlmlPgz74uNi9zOm9Htkb7uBPjoLhfLJkpB6oITR1cESKuTtmmIslkCBubQV22x7Flg=="
+    },
+    "node_modules/@akashic/amflow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.1.0.tgz",
+      "integrity": "sha512-rruOfUXAQNI8V63dH3BMwZPH5ANKmODWbAohF1LvfrA3UixXDMlV2afLdk8km2wZnD8su3i/JATyWov355lFmQ==",
+      "dependencies": {
+        "@akashic/playlog": "~3.1.0"
+      }
     },
     "node_modules/@akashic/eslint-config": {
       "version": "0.1.2",
@@ -70,6 +127,45 @@
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-jest": "^24.1.0"
       }
+    },
+    "node_modules/@akashic/eslint-config/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@akashic/game-configuration": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.4.0.tgz",
+      "integrity": "sha512-AUfpwCKt2wpLzRrTd2l9KdpWNUR/aKyVDsY+9DPmms8kK2TWZ9vALv+FCliJZzf4zzkfswShcdAHQ4yb+YBa5A==",
+      "dependencies": {
+        "@akashic/pdi-types": "~1.3.0"
+      },
+      "optionalDependencies": {
+        "es6-promise": "^4.2.8"
+      }
+    },
+    "node_modules/@akashic/pdi-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@akashic/pdi-types/-/pdi-types-1.3.1.tgz",
+      "integrity": "sha512-9evGYvwamBRejSnqtPnuf5HNGqofzvQe7qSc+chb4mTq203DSC7ArE4WZ52FuCBHTuxwxB1EpHmLKx1QSX3NAw==",
+      "dependencies": {
+        "@akashic/amflow": "~3.1.0",
+        "@akashic/playlog": "~3.1.0",
+        "@akashic/trigger": "~1.0.1"
+      }
+    },
+    "node_modules/@akashic/playlog": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@akashic/playlog/-/playlog-3.1.0.tgz",
+      "integrity": "sha512-O0gByaFr8Cq7Xc9QVg2MamhxZIssfFXvGSEegyJhUz787xCQ4SK5R0fdN0cUMoPJJBay/6W17scG1G8ndxC24g=="
     },
     "node_modules/@akashic/remark-preset-lint": {
       "version": "0.1.1",
@@ -89,6 +185,11 @@
         "remark-lint-no-tabs": "~1.0.2",
         "remark-preset-lint-markdown-style-guide": "~2.1.2"
       }
+    },
+    "node_modules/@akashic/trigger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@akashic/trigger/-/trigger-1.0.1.tgz",
+      "integrity": "sha512-rDQ8iaxw1CWsy1DAoemoOgSpDjgC1o9jLljW/H3S26CxKNl8M4bnrpDIFbgzsld7es5Pdlrs9pWFZYdicpARZw=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.13",
@@ -1024,11 +1125,12 @@
       }
     },
     "node_modules/@types/fs-extra": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.2.tgz",
-      "integrity": "sha512-Q3FWsbdmkQd1ib11A4XNWQvRD//5KpPoGawA8aB2DR7pWKoW9XQv3+dGxD/Z1eVFze23Okdo27ZQytVFlweKvQ==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
       "dev": true,
       "dependencies": {
+        "@types/jsonfile": "*",
         "@types/node": "*"
       }
     },
@@ -1077,6 +1179,15 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
@@ -1087,10 +1198,14 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "14.14.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.26.tgz",
-      "integrity": "sha512-skWxepWOs+VArEBWd2S/VR3wUavioIIx9/HzW+UJiIjtwa6+kNXdsOeq7FfxDXf56hIcL0ieo2brwMgBJ1+lhw==",
-      "dev": true
+      "version": "20.14.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.15.tgz",
+      "integrity": "sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1117,9 +1232,9 @@
       "dev": true
     },
     "node_modules/@types/xml2js": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
-      "integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -2109,11 +2224,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
-        "node": ">= 6"
+        "node": ">=18"
       }
     },
     "node_modules/component-emitter": {
@@ -2564,6 +2679,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "optional": true
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -3438,12 +3559,24 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-      "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -5380,11 +5513,22 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/kind-of": {
@@ -8908,17 +9052,25 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "9.2.0",
@@ -9704,9 +9856,9 @@
       "dev": true
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -9868,24 +10020,81 @@
   },
   "dependencies": {
     "@akashic-extension/akashic-animation": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@akashic-extension/akashic-animation/-/akashic-animation-3.2.1.tgz",
-      "integrity": "sha512-qbsv5B8iTNi08fUCAzvIbxWYLFTifeAFEz7VZnF2aaWoG6E4wzhVp0BC+2rz8wpHlrCtrZa/3Xq1D5PaY15v3g==",
+      "version": "file:../akashic-animation/akashic-extension-akashic-animation-4.1.0.tgz",
+      "integrity": "sha512-XrvbmBjHx1qOvIU5pgr8IhRtcgyhzpfL+10YR3rkRRL7jRu8gqhKzkskrNdYd8xHI6HOvdIdFB42PrA1QgKUFg==",
       "requires": {
-        "@akashic/akashic-engine": "~2.0.0"
+        "@akashic/akashic-engine": "~3.4.3"
       },
       "dependencies": {
         "@akashic/akashic-engine": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-2.0.3.tgz",
-          "integrity": "sha1-alMt5xpTZ+hpsWFFb2CokIkMgzU="
+          "version": "3.4.4",
+          "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.4.4.tgz",
+          "integrity": "sha512-458/BbaVeMn7qCl/woq8c4hfoxsTtuGeqqmitFwnug9lcdMvv3HSSdxqye1Gwr7ztW+71hGEeWypM02i6c3prA==",
+          "requires": {
+            "@akashic/game-configuration": "~1.4.0",
+            "@akashic/pdi-types": "~1.3.0",
+            "@akashic/playlog": "~3.1.0",
+            "@akashic/trigger": "~1.0.1"
+          }
         }
       }
     },
     "@akashic/akashic-engine": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-2.6.6.tgz",
-      "integrity": "sha512-3TMGlwXIEVRXpx2n0Wle+UTW98yOeNLlP8htkb8ZpFGHg3hIKHUq8+rRl+01oj4ND11xaFVuizvfRg5htjO2Rw=="
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.18.1.tgz",
+      "integrity": "sha512-L27RN1MgG0lngDwjZ4Z8+GarmOh7UJKznfAgYKHpQt7RdoAaYmJ76tHlG1WCasiTVrwmggIP2Bqt8YMu9W1FBQ==",
+      "requires": {
+        "@akashic/game-configuration": "~2.2.0",
+        "@akashic/pdi-types": "^1.13.0",
+        "@akashic/playlog": "~3.3.0",
+        "@akashic/trigger": "~2.1.0"
+      },
+      "dependencies": {
+        "@akashic/amflow": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.3.0.tgz",
+          "integrity": "sha512-+dDBtwPfAOeslclGYYKF1yoGg+NiLnDHO3DVIGorkzSd9YLwf+LJGK4sQxRvltKBygmHmhaVrjP7de0PMA+c4Q==",
+          "requires": {
+            "@akashic/playlog": "~3.3.0"
+          }
+        },
+        "@akashic/game-configuration": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-2.2.0.tgz",
+          "integrity": "sha512-+sAREJpjwGxN2YhzID+ov1gx2xF5MXgEHdCMc1QnZvtRwj5A1TZZfHFM0+KxdpmJg1OT0LGmApZClZDgMDpqlg==",
+          "requires": {
+            "@akashic/pdi-types": "^1.11.1"
+          }
+        },
+        "@akashic/pdi-types": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@akashic/pdi-types/-/pdi-types-1.14.0.tgz",
+          "integrity": "sha512-QwCQHII8nNdO6nOc/x1MAyN6PGpzsSrhBpq+WYXlav3MbDxZEX9JGJEIbrNdAfEZMK5CJ5LCpkVvQxTOefnZwg==",
+          "requires": {
+            "@akashic/amflow": "~3.3.0",
+            "@akashic/playlog": "~3.3.0",
+            "@akashic/trigger": "~2.1.0"
+          }
+        },
+        "@akashic/playlog": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/@akashic/playlog/-/playlog-3.3.0.tgz",
+          "integrity": "sha512-pqX31etu1H9DGvfAuW8w4TiUdcKUUoTBJQd6HF1OZWMDC2O6RSx8DTndYa4Eqr9wll+bs3aRJqUHcVdDJKWevw=="
+        },
+        "@akashic/trigger": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@akashic/trigger/-/trigger-2.1.0.tgz",
+          "integrity": "sha512-Ae+rhN6R2jnAwd4rZhXIlmlPgz74uNi9zOm9Htkb7uBPjoLhfLJkpB6oITR1cESKuTtmmIslkCBubQV22x7Flg=="
+        }
+      }
+    },
+    "@akashic/amflow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.1.0.tgz",
+      "integrity": "sha512-rruOfUXAQNI8V63dH3BMwZPH5ANKmODWbAohF1LvfrA3UixXDMlV2afLdk8km2wZnD8su3i/JATyWov355lFmQ==",
+      "requires": {
+        "@akashic/playlog": "~3.1.0"
+      }
     },
     "@akashic/eslint-config": {
       "version": "0.1.2",
@@ -9896,7 +10105,39 @@
         "@typescript-eslint/parser": "^4.7.0",
         "eslint": "^7.13.0",
         "typescript": "^3.7.5"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+          "dev": true
+        }
       }
+    },
+    "@akashic/game-configuration": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.4.0.tgz",
+      "integrity": "sha512-AUfpwCKt2wpLzRrTd2l9KdpWNUR/aKyVDsY+9DPmms8kK2TWZ9vALv+FCliJZzf4zzkfswShcdAHQ4yb+YBa5A==",
+      "requires": {
+        "@akashic/pdi-types": "~1.3.0",
+        "es6-promise": "^4.2.8"
+      }
+    },
+    "@akashic/pdi-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@akashic/pdi-types/-/pdi-types-1.3.1.tgz",
+      "integrity": "sha512-9evGYvwamBRejSnqtPnuf5HNGqofzvQe7qSc+chb4mTq203DSC7ArE4WZ52FuCBHTuxwxB1EpHmLKx1QSX3NAw==",
+      "requires": {
+        "@akashic/amflow": "~3.1.0",
+        "@akashic/playlog": "~3.1.0",
+        "@akashic/trigger": "~1.0.1"
+      }
+    },
+    "@akashic/playlog": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@akashic/playlog/-/playlog-3.1.0.tgz",
+      "integrity": "sha512-O0gByaFr8Cq7Xc9QVg2MamhxZIssfFXvGSEegyJhUz787xCQ4SK5R0fdN0cUMoPJJBay/6W17scG1G8ndxC24g=="
     },
     "@akashic/remark-preset-lint": {
       "version": "0.1.1",
@@ -9916,6 +10157,11 @@
         "remark-lint-no-tabs": "~1.0.2",
         "remark-preset-lint-markdown-style-guide": "~2.1.2"
       }
+    },
+    "@akashic/trigger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@akashic/trigger/-/trigger-1.0.1.tgz",
+      "integrity": "sha512-rDQ8iaxw1CWsy1DAoemoOgSpDjgC1o9jLljW/H3S26CxKNl8M4bnrpDIFbgzsld7es5Pdlrs9pWFZYdicpARZw=="
     },
     "@babel/code-frame": {
       "version": "7.12.13",
@@ -10704,11 +10950,12 @@
       }
     },
     "@types/fs-extra": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.2.tgz",
-      "integrity": "sha512-Q3FWsbdmkQd1ib11A4XNWQvRD//5KpPoGawA8aB2DR7pWKoW9XQv3+dGxD/Z1eVFze23Okdo27ZQytVFlweKvQ==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
       "dev": true,
       "requires": {
+        "@types/jsonfile": "*",
         "@types/node": "*"
       }
     },
@@ -10757,6 +11004,15 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mdast": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
@@ -10767,10 +11023,13 @@
       }
     },
     "@types/node": {
-      "version": "14.14.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.26.tgz",
-      "integrity": "sha512-skWxepWOs+VArEBWd2S/VR3wUavioIIx9/HzW+UJiIjtwa6+kNXdsOeq7FfxDXf56hIcL0ieo2brwMgBJ1+lhw==",
-      "dev": true
+      "version": "20.14.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.15.tgz",
+      "integrity": "sha512-Fz1xDMCF/B00/tYSVMlmK7hVeLh7jE5f3B7X1/hmV0MJBwE27KlS7EvD/Yp+z1lm8mVhwV5w+n8jOZG8AfTlKw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -10797,9 +11056,9 @@
       "dev": true
     },
     "@types/xml2js": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
-      "integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -11522,9 +11781,9 @@
       }
     },
     "commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -11878,6 +12137,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "optional": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -12583,12 +12848,20 @@
       }
     },
     "fs-extra": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-      "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
+        }
       }
     },
     "fs.realpath": {
@@ -14054,11 +14327,19 @@
       }
     },
     "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+          "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
+        }
       }
     },
     "kind-of": {
@@ -16756,9 +17037,15 @@
       }
     },
     "typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "unified": {
@@ -17347,9 +17634,9 @@
       "dev": true
     },
     "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "@akashic/eslint-config": "^0.1.2",
     "@akashic/remark-preset-lint": "~0.1.1",
     "@types/commander": "2.12.0",
-    "@types/fs-extra": "5.0.2",
-    "@types/node": "~14.14.16",
-    "@types/xml2js": "~0.4.8",
+    "@types/fs-extra": "^11.0.4",
+    "@types/node": "^20.14.0",
+    "@types/xml2js": "^0.4.14",
     "@typescript-eslint/eslint-plugin": "^4.15.0",
     "del": "^2.2.2",
     "eslint": "^7.19.0",
@@ -45,14 +45,14 @@
     "jest": "~26.6.3",
     "remark-cli": "^9.0.0",
     "rimraf": "^3.0.2",
-    "typescript": "^3.9.7"
+    "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@akashic-extension/akashic-animation": "~3.2.0",
-    "@akashic/akashic-engine": "~2.6.2",
-    "commander": "^5.0.0",
-    "fs-extra": "^2.0.0",
-    "xml2js": "^0.4.15"
+    "@akashic-extension/akashic-animation": "file:../akashic-animation/akashic-extension-akashic-animation-4.1.0.tgz",
+    "@akashic/akashic-engine": "^3.18.1",
+    "commander": "^12.1.0",
+    "fs-extra": "^11.2.0",
+    "xml2js": "^0.6.2"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@akashic-extension/akashic-animation": "file:../akashic-animation/akashic-extension-akashic-animation-4.1.0.tgz",
+    "@akashic-extension/akashic-animation": "^4.2.0",
     "@akashic/akashic-engine": "^3.18.1",
     "commander": "^12.1.0",
     "fs-extra": "^11.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic-extension/ss2asa",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Convert SpriteStudio files to akashic-animation files.",
   "bin": {
     "ss2asa": "bin/run"

--- a/spec/SpriteStudioSpec.js
+++ b/spec/SpriteStudioSpec.js
@@ -4,31 +4,16 @@ var path = require("path");
 var U = require("../lib/Utils.js");
 var SS = require("../lib/SpriteStudio.js");
 
-// 非同期読み込み `U.loadXmlAsJsAsync()` を promise 化
-function loadXmlPromise(fname) {
-	var promise = new Promise(function (resolve, reject) {
-		U.loadXmlAsJsAsync(fname, function(err, result) {
-			if (! err) {
-				resolve(result);
-			} else {
-				reject(err);
-			}
-		});
-	});
-
-	return promise;
-}
-
 function loadProjectPromise(fname) {
 	var pathToProj = path.dirname(fname);
 
-	var promise = loadXmlPromise(fname)
+	var promise = U.loadXMLFileAsyncPromise(fname)
 	.then(function(result) {
 		var fset = SS.createRelatedFileSetFromSSPJ(result);
 		var allFiles = fset.ssaeFileNames.concat(fset.ssceFileNames);
 		var promises = allFiles.map(function(fname) {
 			fname = path.join(pathToProj, fname);
-			var r = loadXmlPromise(fname);
+			var r = U.loadXMLFileAsyncPromise(fname);
 			return r;
 		});
 		return Promise.all(promises);

--- a/spec/UtilsSpec.js
+++ b/spec/UtilsSpec.js
@@ -1,14 +1,12 @@
 var Utils = require("../lib/Utils.js");
 
-describe("Utils.", function () {
-
-	describe("loadXmlAsJsAsync", function() {
-		it("can load an xml file and then return it in json", function(done) {
-			Utils.loadXmlAsJsAsync("./spec/support/src.xml", function(err, result) {
-				expect(err).toBeFalsy();
-				expect(result.SpriteStudioProject.name[0]).toBe("pl00_all_motion");
-				done(); // 非同期処理はこのようにして終了を伝える
-			});
-		});
+describe("Utils.", () => {
+	describe("loadXmlAsJsAsync", () => {
+		it("can load an xml file and then return an object", () =>
+			Utils.loadXMLFileAsyncPromise("./spec/support/src.xml")
+				.then(result => {
+					expect(result.SpriteStudioProject.name[0]).toBe("pl00_all_motion");
+				})
+		);
 	});
 });

--- a/spec/UtilsSpec.js
+++ b/spec/UtilsSpec.js
@@ -2,11 +2,11 @@ var Utils = require("../lib/Utils.js");
 
 describe("Utils.", () => {
 	describe("loadXmlAsJsAsync", () => {
-		it("can load an xml file and then return an object", () =>
-			Utils.loadXMLFileAsyncPromise("./spec/support/src.xml")
+		it("can load an xml file and then return an object", () => {
+			return Utils.loadXMLFileAsyncPromise("./spec/support/src.xml")
 				.then(result => {
 					expect(result.SpriteStudioProject.name[0]).toBe("pl00_all_motion");
 				})
-		);
+		});
 	});
 });

--- a/spec/converterSpec.js
+++ b/spec/converterSpec.js
@@ -35,29 +35,9 @@ describe("converter.", function () {
 				projFileName: path.join(__dirname, "..", "spec", "project", "SupportAlphaBlend", "SupportAlphaBlend.sspj"),
 				outDir: "dummy",
 				addPrefix: true,
-				prefixes: [],
+				prefixes: ["","","","",""],
 				bundleAll: true
 			});
-		});
-	});
-
-	describe("createRelatedFileInfo()", function() {
-		it("should return related file info object constructed properly", function() {
-			var asapj = {
-				boneSetFileNames: ["hoge.asabn"],
-				skinFileNames: ["hoge.asask"],
-				animationFileNames: ["hoge.asaan"],
-			};
-			var imageFileNames = ["hoge.png"];
-
-			var r = new C.RelatedFileInfo(imageFileNames, asapj);
-
-			expect(JSON.stringify(r)).toBe(JSON.stringify({
-				boneSetFileNames: ["hoge.asabn"],
-				skinFileNames: ["hoge.asask"],
-				animationFileNames: ["hoge.asaan"],
-				imageFileNames: ["hoge.png"]
-			}));
 		});
 	});
 });

--- a/src/SpriteStudio.ts
+++ b/src/SpriteStudio.ts
@@ -252,7 +252,7 @@ export interface LoadFromSSAEOptionObject {
 	/**
 	 * 真の時、Akashic Animation では利用できない属性を無視し、エラーにしない。
 	 */
-	ignoreUnknownAttribute?: boolean;
+	ignoreUnknownAttributes?: boolean;
 }
 
 export function loadFromSSAE(proj: Project, data: any, option: LoadFromSSAEOptionObject): void {
@@ -305,7 +305,7 @@ export function loadFromSSAE(proj: Project, data: any, option: LoadFromSSAEOptio
 		ssAnimeList,
 		skinNames,
 		option.outputUserData,
-		option.ignoreUnknownAttribute
+		option.ignoreUnknownAttributes
 	);
 
 	animations.forEach((animation: Animation) => {
@@ -790,17 +790,17 @@ function loadKeyFrames(
 	keys: any[],
 	skinNames: string[],
 	outputUserData: boolean,
-	ignoreUnknownAttribute: boolean
+	ignoreUnknownAttributes: boolean
 ): Curve<any> {
 	const ssAttr = _ssAttr as keyof typeof ssAttr2asaAttr;
 	const attribute = ssAttr2asaAttr[ssAttr];
 
 	if (attribute == null) {
-		if (ignoreUnknownAttribute) {
+		if (ignoreUnknownAttributes) {
 			console.log(`Ignore unknonwn attribute: ${ssAttr}`);
 			return undefined;
 		} else {
-			throw Error("Unknown attribute: " + ssAttr);
+			throw Error(`Unknown attribute: ${ssAttr}`);
 		}
 	}
 
@@ -858,7 +858,7 @@ function convertSSAnime(
 	ssAnime: any,
 	skinNames: string[],
 	outputUserData: boolean,
-	ignoreUnknownAttribute: boolean
+	ignoreUnknownAttributes: boolean
 ): Animation {
 	const dstAnime = new Animation();
 	dstAnime.name = ssAnime.name[0];
@@ -880,7 +880,7 @@ function convertSSAnime(
 				const keys: any[] = attribute.key;
 				const ssAttr = attribute.$.tag; // e.g. POSX, POSY, ...
 
-				const curve = loadKeyFrames(ssAttr, keys, skinNames, outputUserData, ignoreUnknownAttribute);
+				const curve = loadKeyFrames(ssAttr, keys, skinNames, outputUserData, ignoreUnknownAttributes);
 				if (curve) {
 					mirrorCurve(curve);
 					curveTie.curves.push(curve); // stored
@@ -903,7 +903,7 @@ function loadAnimationsFromSSAnimeList(
 	ssAnimeList: any[],
 	skinNames: string[],
 	outputUserData: boolean,
-	ignoreUnknownAttribute: boolean
+	ignoreUnknownAttributes: boolean
 ): Animation[] {
 	const animations: Animation[] = [];
 	for (let i = 0; i < ssAnimeList.length; i++) {
@@ -912,7 +912,7 @@ function loadAnimationsFromSSAnimeList(
 		if (ssAnime.isSetup && ssAnime.isSetup[0] === "1") {
 			continue;
 		}
-		const anime = convertSSAnime(ssAnime, skinNames, outputUserData, ignoreUnknownAttribute);
+		const anime = convertSSAnime(ssAnime, skinNames, outputUserData, ignoreUnknownAttributes);
 		animations.push(anime);
 	}
 

--- a/src/SpriteStudio.ts
+++ b/src/SpriteStudio.ts
@@ -89,11 +89,17 @@ export interface Combo {
 	skinNames: string[];
 }
 
+/**
+ * SpriteStudio のレイアウト情報のサイズ。
+ */
 interface LayoutSize {
 	width: number;
 	height: number;
 }
 
+/**
+ * プロジェクトのユーザデータ。
+ */
 export interface ProjectUserData {
 	combinationInfo?: Combo[];
 	layoutSizes?: Record<string, LayoutSize>;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -18,6 +18,7 @@ export function loadXMLFileAsyncPromise(fname: string): Promise<Record<string, a
 			parser.parseString(data, (err, result) => {
 				if (err) {
 					reject(err);
+					return;
 				}
 				resolve(result);
 			});

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,18 +1,30 @@
 import fs = require("fs");
 import xml2js = require("xml2js");
 
-export function loadXmlAsJsAsync(fname: string, callback: (err: any, result: any) => void): void {
-	fs.readFile(fname, {encoding: "utf8"}, (err: Error, data: string) => {
-		if (! err) {
+/**
+ * XMLファイルをロードしてオブジェクトに変換する。
+ *
+ * @param fname xmlファイル名
+ * @returns オブジェクトまたはnullを返すプロミス
+ */
+export function loadXMLFileAsyncPromise(fname: string): Promise<Record<string, any>> {
+	return new Promise((resolve, reject) => {
+		fs.readFile(fname, { encoding: "utf8" }, (err, data) => {
+			if (err) {
+				reject(err);
+				return;
+			}
 			const parser = new xml2js.Parser();
-			parser.parseString(data, (err: any, result: any) => {
-				callback(err, result);
+			parser.parseString(data, (err, result) => {
+				if (err) {
+					reject(err);
+				}
+				resolve(result);
 			});
-		} else {
-			callback(err, data);
-		}
+		});
 	});
-}
+};
+
 
 export class Logger {
 	log: (...args: any[]) => void;
@@ -26,4 +38,134 @@ export class Logger {
 			this.log = (..._args: any[]) => { /* nothing to do */ };
 		}
 	}
+}
+
+function notUndefinedKeys(obj: any): string[] {
+	const keys = Object.keys(obj);
+	const result: string[] = [];
+
+	for (const key of keys) {
+		if (obj[key] !== undefined) {
+			result.push(key);
+		}
+	}
+
+	return result;
+}
+
+// based on https://github.com/epoberezkin/fast-deep-equal
+function _deepEqual(a: any, b: any, info: any[]): boolean {
+	if (a === b) return true;
+
+	if (a && b && typeof a == "object" && typeof b == "object") {
+		// コンストラクタを比較しない。プロパティが一致していれば同一とみなす。
+		// TODO: Bone クラスなどを interface に変更することを検討する
+		// if (a.constructor !== b.constructor) {
+		// 	info.push("a is " + a.constructor.name + ", b is " + b.constructor.name);
+		// 	return false;
+		// }
+
+		let length, i, keys;
+		if (Array.isArray(a)) {
+			length = a.length;
+			if (length !== b.length) {
+				info.push("a.length=" + a.length + ", b.length=" + b.length);
+				return false;
+			}
+			for (i = length; i-- !== 0;) {
+				info.push(i);
+				if (!_deepEqual(a[i], b[i], info)) {
+					return false;
+				}
+				info.pop();
+			}
+			return true;
+		}
+
+		if (a.constructor === RegExp) {
+			const result = a.source === b.source && a.flags === b.flags;
+			if (result) {
+				return true;
+			}
+			info.push("a.source=" + a.source + ", b.source=" + b.source + ", a.flags=" + a.flags + ", b.flags=" + b.flags);
+			return false;
+		}
+		if (a.valueOf !== Object.prototype.valueOf) {
+			const result = a.valueOf() === b.valueOf();
+			if (result) {
+				return true;
+			}
+			info.push("a.valueOf()=" + a.valueOf() + ", b.valueOf()=" + b.valueOf());
+			return false;
+		}
+		if (a.toString !== Object.prototype.toString) {
+			const result = a.toString() === b.toString();
+			if (result) {
+				return true;
+			}
+			info.push("a.toString()=" + a.toString() + ", b.toString()=" + b.toString());
+			return false;
+		}
+
+		// undefined を持つプロパティは比較しない。つまり、一方にあるプロパティ
+		// の値が undefined でもう一方にはそのプロパティが存在しないこと、を
+		// 許容する
+		const aKeys = notUndefinedKeys(a);
+		const bKeys = notUndefinedKeys(b);
+		if (aKeys.length !== bKeys.length) {
+			info.push(
+				"a.keys=[" + aKeys.sort().join(",") + "]" + ", " +
+				"b.keys=[" + bKeys.sort().join(",") + "]"
+			);
+			return false;
+		}
+		keys = aKeys;
+		length = aKeys.length;
+
+		for (i = length; i-- !== 0;) {
+			info.push(keys[i]);
+			if (!Object.prototype.hasOwnProperty.call(b, keys[i])) {
+				info.push("b does not have key " + keys[i]);
+				return false;
+			}
+			info.pop();
+		}
+
+		for (i = length; i-- !== 0;) {
+			const key = keys[i];
+			info.push(key);
+			if (!_deepEqual(a[key], b[key], info)) {
+				return false;
+			}
+			info.pop();
+		}
+
+		return true;
+	}
+
+	// true if both NaN, false otherwise
+	return a !== a && b !== b;
+}
+
+/**
+ * オブジェクトを比較する
+ *
+ * 値が undefined のプロパティは比較しない。
+ *
+ * @param a オブジェクト
+ * @param b オブジェクト
+ * @returns オブジェクトが一致した時、真。一致しなかった時、一致しなかったプロパティのパスと詳細の文字列
+ */
+export function deepEqual(a: any, b: any): true | string {
+	const info: any[] = [];
+
+	const result = _deepEqual(a, b, info);
+
+	if (result) {
+		return true;
+	}
+
+	const detail = info.pop();
+
+	return info.join(".") + " (" + detail + ")";
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,7 @@ C.convert({
 	verbose:               !!opts.verbose,
 	bundleAll:             !!opts.bundleAll,
 	prefixes:              opts.setPrefix,
+	outputRelatedFileInfo: !!opts.relatedFileInfo,
 	porter:                opts.porter,
 
 	asaanLongName:         !!opts.longName,
@@ -55,7 +56,6 @@ C.convert({
 	labelAsUserData:       !!opts.labelAsUserData,
 	outputUserData:        !!opts.userData,
 	outputComboInfo:       !!opts.combinationInfo,
-	outputRelatedFileInfo: !!opts.relatedFileInfo,
 	outputLayoutSize:      !!opts.layoutSize,
 	ignoreUnknownAttribute:!!opts.ignoreUnknownAttribute,
 }).catch(err => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,8 @@ program
 	.option(
 		"-P, --set-prefix <[pj],[bn],[sk],[an],[ef]>",
 		"set file name prefixes",
-		list => list.split(",")
+		list => list.split(","),
+		C.DEFAULT_PREFIXES
 	)
 	.addOption(new Option("--porter <porter>", "set porter").choices(["none", "aop"]).default("none"))
 	.option("--ignore-unknown-attribute", "ignore unknown attribute")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ program
 	)
 	.addOption(new Option("--porter <porter>", "set porter").choices(["none", "aop"]).default("none"))
 	.option("--ignore-unknown-attributes", "ignore unknown attributes")
+	.option("--debug-verify-porter", "verify porter intengrity by importing data")
 	.option("-v, --verbose", "output verbosely")
 	.parse(process.argv);
 
@@ -50,6 +51,7 @@ C.convert({
 	prefixes:               opts.setPrefix,
 	outputRelatedFileInfo:  !!opts.relatedFileInfo,
 	porter:                 opts.porter,
+	debugVerifyPorter:      !!opts.debugVerifyPorter,
 
 	asaanLongName:          !!opts.longName,
 	deleteHidden:           !!opts.deleteHidden,
@@ -57,7 +59,7 @@ C.convert({
 	outputUserData:         !!opts.userData,
 	outputComboInfo:        !!opts.combinationInfo,
 	outputLayoutSize:       !!opts.layoutSize,
-	ignoreUnknownAttributes:!!opts.ignoreUnknownAttribute,
+	ignoreUnknownAttributes:!!opts.ignoreUnknownAttributes,
 }).catch(err => {
 	console.log(err);
 	process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,7 @@ program
 		C.DEFAULT_PREFIXES
 	)
 	.addOption(new Option("--porter <porter>", "set porter").choices(["none", "aop"]).default("none"))
-	.option("--ignore-unknown-attribute", "ignore unknown attribute")
+	.option("--ignore-unknown-attributes", "ignore unknown attributes")
 	.option("-v, --verbose", "output verbosely")
 	.parse(process.argv);
 
@@ -42,22 +42,22 @@ if (args.length === 0) {
 const opts = program.opts();
 
 C.convert({
-	projFileName:          args[0],
-	outDir:                opts.outDir,
-	addPrefix:             !!opts.addPrefix,
-	verbose:               !!opts.verbose,
-	bundleAll:             !!opts.bundleAll,
-	prefixes:              opts.setPrefix,
-	outputRelatedFileInfo: !!opts.relatedFileInfo,
-	porter:                opts.porter,
+	projFileName:           args[0],
+	outDir:                 opts.outDir,
+	addPrefix:              !!opts.addPrefix,
+	verbose:                !!opts.verbose,
+	bundleAll:              !!opts.bundleAll,
+	prefixes:               opts.setPrefix,
+	outputRelatedFileInfo:  !!opts.relatedFileInfo,
+	porter:                 opts.porter,
 
-	asaanLongName:         !!opts.longName,
-	deleteHidden:          !!opts.deleteHidden,
-	labelAsUserData:       !!opts.labelAsUserData,
-	outputUserData:        !!opts.userData,
-	outputComboInfo:       !!opts.combinationInfo,
-	outputLayoutSize:      !!opts.layoutSize,
-	ignoreUnknownAttribute:!!opts.ignoreUnknownAttribute,
+	asaanLongName:          !!opts.longName,
+	deleteHidden:           !!opts.deleteHidden,
+	labelAsUserData:        !!opts.labelAsUserData,
+	outputUserData:         !!opts.userData,
+	outputComboInfo:        !!opts.combinationInfo,
+	outputLayoutSize:       !!opts.layoutSize,
+	ignoreUnknownAttributes:!!opts.ignoreUnknownAttribute,
 }).catch(err => {
 	console.log(err);
 	process.exit(1);

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -160,9 +160,9 @@ export function convert(_options: Options): Promise<any> {
 			}
 
 			if (options.bundleAll) {
-				writeAllIntoProjectFile(proj, options.outDir, options.prefixes, options.outputRelatedFileInfo, options.porter);
+				writeAsProjectV3(proj, options.outDir, options.prefixes, options.outputRelatedFileInfo, options.porter);
 			} else {
-				writeAll(proj, options.outDir, options.prefixes, options.outputRelatedFileInfo, options.porter);
+				writeAsProjectV2(proj, options.outDir, options.prefixes, options.outputRelatedFileInfo, options.porter);
 			}
 		});
 }
@@ -258,7 +258,7 @@ function verifyPorter(
 	assertDeepEqual(proj.effects, deserializedEffects);
 }
 
-function writeAllPorterNone(proj: SS.Project, outDir: string, prefixes: string[], version: string): ProjectV2 {
+function writeRelatedFilesAsV2PorterNone(proj: SS.Project, outDir: string, prefixes: string[], version: string): ProjectV2 {
 	const boneSetFileNames = writeNamedObjects(proj.boneSets, ".asabn", outDir, version, prefixes[Prefix.Bone]);
 	const skinFileNames = writeNamedObjects(proj.skins, ".asask", outDir, version, prefixes[Prefix.Skin]);
 	const animationFileNames = writeNamedObjects(proj.animations, ".asaan", outDir, version, prefixes[Prefix.Anim]);
@@ -273,7 +273,7 @@ function writeAllPorterNone(proj: SS.Project, outDir: string, prefixes: string[]
 	};
 }
 
-function writeAllPorterAOP(proj: SS.Project, outDir: string, prefixes: string[], version: string): ProjectV2 {
+function writeRelatedFilesAsV2PorterAOP(proj: SS.Project, outDir: string, prefixes: string[], version: string): ProjectV2 {
 	const exporter = new aop.ArrayOrientedExporter();
 
 	const compactAnimations = proj.animations.map(anim => {
@@ -342,13 +342,13 @@ function writeAllPorterAOP(proj: SS.Project, outDir: string, prefixes: string[],
  * @param prefixes
  * @param outputRelatedFileInfo
  */
-function writeAll(proj: SS.Project, outDir: string, prefixes: string[], outputRelatedFileInfo: boolean, porter: PorterType): void {
+function writeAsProjectV2(proj: SS.Project, outDir: string, prefixes: string[], outputRelatedFileInfo: boolean, porter: PorterType): void {
 	const version = FILEFORMAT_VERSION_V2;
 
 	const projectV2 = porter === "none"
-		? writeAllPorterNone(proj, outDir, prefixes, version)
+		? writeRelatedFilesAsV2PorterNone(proj, outDir, prefixes, version)
 		: porter === "aop"
-			? writeAllPorterAOP(proj, outDir, prefixes, version)
+			? writeRelatedFilesAsV2PorterAOP(proj, outDir, prefixes, version)
 			: null;
 
 	if (projectV2 == null) {
@@ -379,7 +379,7 @@ function writeAll(proj: SS.Project, outDir: string, prefixes: string[], outputRe
 	vlog.log("write " + pjFname);
 }
 
-function createContentsV3PorterNone(proj: SS.Project): Content<any>[] {
+function createContentsPorterNone(proj: SS.Project): Content<any>[] {
 	const boneSetContents = proj.boneSets.map(boneSet =>
 		new Content("bone", boneSet.name, boneSet)
 	);
@@ -408,7 +408,7 @@ function createContentsV3PorterNone(proj: SS.Project): Content<any>[] {
 	return contents;
 }
 
-function createContentsV3PorterAOP(proj: SS.Project): Content<any>[] {
+function createContentsPorterAOP(proj: SS.Project): Content<any>[] {
 	const exporter = new aop.ArrayOrientedExporter();
 
 	const boneSetContents = proj.boneSets.map(boneSet =>
@@ -441,14 +441,14 @@ function createContentsV3PorterAOP(proj: SS.Project): Content<any>[] {
 }
 
 /**
- * プロジェクトファイルおよびその他関連ファイルをV3形式で出力する。
+ * プロジェクトファイルをV3形式で出力する。
  *
- * @param proj
- * @param outDir
- * @param prefixes
- * @param outputRelatedFileInfo
+ * @param proj SpriteStudio プロジェクト
+ * @param outDir 出力ディレクトリ
+ * @param prefixes ファイル名プレフィックス
+ * @param outputRelatedFileInfo 真の時、関連ファイル情報を出力する
  */
-function writeAllIntoProjectFile(
+function writeAsProjectV3(
 	proj: SS.Project,
 	outDir: string,
 	prefixes: string[],
@@ -458,9 +458,9 @@ function writeAllIntoProjectFile(
 	const version = FILEFORMAT_VERSION;
 
 	const contents = porter === "none"
-		? createContentsV3PorterNone(proj)
+		? createContentsPorterNone(proj)
 		: porter === "aop"
-			? createContentsV3PorterAOP(proj)
+			? createContentsPorterAOP(proj)
 			: null;
 
 	if (contents == null) {

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -87,6 +87,11 @@ export interface Options extends SS.LoadFromSSAEOptionObject {
 	prefixes?: string[];
 
 	/**
+	 * 真の時、関連ファイル情報を出力する。
+	 */
+	outputRelatedFileInfo?: boolean;
+
+	/**
 	 * ポーターの種類。
 	 *
 	 * 省略時、"none"。
@@ -180,8 +185,6 @@ function completeOptions(opts: Options): Required<Options> {
 			: DEFAULT_PREFIXES.map(_p => "");
 	}
 
-	console.log(prefixes);
-
 	return {
 		projFileName: opts.projFileName,
 		outDir: opts.outDir,
@@ -189,6 +192,7 @@ function completeOptions(opts: Options): Required<Options> {
 		verbose: !!opts.verbose,
 		bundleAll: !!opts.bundleAll,
 		prefixes,
+		outputRelatedFileInfo: !!opts.outputRelatedFileInfo,
 		porter: opts.porter ?? "none",
 
 		// SS.LoadFromSSAEOptionObject
@@ -197,7 +201,6 @@ function completeOptions(opts: Options): Required<Options> {
 		labelAsUserData: !!opts.labelAsUserData,
 		outputUserData: !!opts.outputUserData,
 		outputComboInfo: !!opts.outputComboInfo,
-		outputRelatedFileInfo: !!opts.outputRelatedFileInfo,
 		outputLayoutSize: !!opts.outputLayoutSize,
 		ignoreUnknownAttribute: !!opts.ignoreUnknownAttribute,
 	};

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -171,13 +171,13 @@ function completeOptions(opts: Options): Required<Options> {
 	let prefixes: string[];
 
 	if (Array.isArray(opts.prefixes)) {
-		prefixes = [];
-		for (let i = 0; i < DEFAULT_PREFIXES.length; i++) {
-			prefixes.push(opts.prefixes[i] ?? DEFAULT_PREFIXES[i]);
+		prefixes = [...opts.prefixes];
+		for (let i = prefixes.length; i < DEFAULT_PREFIXES.length; i++) {
+			prefixes.push(DEFAULT_PREFIXES[i]);
 		}
 	} else {
 		prefixes = opts.addPrefix
-			? DEFAULT_PREFIXES
+			? [...DEFAULT_PREFIXES]
 			: DEFAULT_PREFIXES.map(_p => "");
 	}
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -127,10 +127,6 @@ export function convert(_options: Options): Promise<any> {
 
 	vlog.log("option:", options);
 
-	if (options.prefixes.length < DEFAULT_PREFIXES.length) {
-		return Promise.reject(`Too few prefixes ${JSON.stringify(options.prefixes)}`);
-	}
-
 	return Promise.resolve()
 		.then(() => new Promise<void>((resolve, reject) =>
 			fs.ensureDir(options.outDir, err => err ? reject(err) : resolve())

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -202,7 +202,7 @@ function completeOptions(opts: Options): Required<Options> {
 		outputUserData: !!opts.outputUserData,
 		outputComboInfo: !!opts.outputComboInfo,
 		outputLayoutSize: !!opts.outputLayoutSize,
-		ignoreUnknownAttribute: !!opts.ignoreUnknownAttribute,
+		ignoreUnknownAttributes: !!opts.ignoreUnknownAttributes,
 	};
 }
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -468,11 +468,13 @@ function writeAllIntoProjectFile(
 	}
 
 	if (outputRelatedFileInfo) {
-		const idx = contents.findIndex(content => content.type === "project");
-		if (idx === -1) {
+		const content = contents.find(content => content.type === "project");
+
+		if (content == null) {
 			throw new Error("Project not found.");
 		}
-		const projectV3: ProjectV3 = contents[idx].data;
+
+		const projectV3 = content.data as ProjectV3;
 		const relatedFileInfo: RelatedFileInfo = {
 			boneSetFileNames: [],
 			skinFileNames: [],
@@ -480,6 +482,7 @@ function writeAllIntoProjectFile(
 			effectFileNames: [],
 			imageFileNames: proj.imageFileNames,
 		};
+
 		projectV3.userData = {
 			...projectV3.userData,
 			relatedFileInfo

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -4,31 +4,101 @@ import fs = require("fs-extra");
 /* eslint import/order: 0 */
 import g = require("@akashic/akashic-engine");
 (<any>global).g = g;
-import { Skin, BoneSet, ContainerV2, ContainerV3, Content, ContentType, AnimeParams } from "@akashic-extension/akashic-animation";
+import {
+	ContainerV2,
+	ContainerV3,
+	Content,
+	ProjectV2,
+	ProjectV3,
+	aop,
+} from "@akashic-extension/akashic-animation";
 /* eslint import/order: 2 */
 import SS = require("./SpriteStudio");
 import U = require("./Utils");
 
-//
-// Converter's option interface
-//
-export interface Options extends SS.LoadFromSSAEOptionObject {
-	projFileName: string;
-	outDir: string;
-	addPrefix?: boolean;
-	verbose?: boolean;
-	bundleAll?: boolean;
-	prefixes?: string[];
+/**
+ * 関連ファイル情報。
+ */
+interface RelatedFileInfo {
+	boneSetFileNames: string[];
+	skinFileNames: string[];
+	animationFileNames: string[];
+	effectFileNames: string[];
+	imageFileNames: string[];
 }
 
-//
-// Consts
-//
+/**
+ * 名前付きデータ。
+ */
+interface NamedData<T> {
+	name: string;
+	data: T;
+}
+
+/**
+ * コンバータで利用できるポーターの種類。
+ *
+ * - none: ポーターを利用しない
+ * - aop: Array Oriented Porter
+ */
+export type PorterType = "none" | "aop";
+
+/**
+ * コンバータオプション。
+ */
+export interface Options extends SS.LoadFromSSAEOptionObject {
+	/**
+	 * プロジェクトファイル名。
+	 */
+	projFileName: string;
+
+	/**
+	 * 出力ディレクトリ。
+	 */
+	outDir: string;
+
+	/**
+	 * 真の時、ファイル名にプレフィックスを付加する。
+	 *
+	 * 省略時、偽。
+	 */
+	addPrefix?: boolean;
+
+	/**
+	 * 真の時、冗長なログを出力する。
+	 *
+	 * 省略時、偽。
+	 */
+	verbose?: boolean;
+
+	/**
+	 * 真の時、全てのアニメーションデータをプロジェクトファイルにバンドルする。
+	 *
+	 * 省略時、偽。
+	 */
+	bundleAll?: boolean;
+
+	/**
+	 * ファイル名プレフィックス。
+	 *
+	 * 省略時、addPrefix が真であれば ["pj_", "bn_", "sk_", "an_", "ef_"]。
+	 * addPrefix が偽であれば ["", "", "", "", ""]。
+	 */
+	prefixes?: string[];
+
+	/**
+	 * ポーターの種類。
+	 *
+	 * 省略時、"none"。
+	 */
+	porter?: PorterType;
+}
+
 export const DEFAULT_PREFIXES = ["pj_", "bn_", "sk_", "an_", "ef_"];
 const FILEFORMAT_VERSION_V2: string = "2.0.0"; // file format version (v2)
 const FILEFORMAT_VERSION: string = "3.0.0";    // file format version
+const FS_WRITE_OPTION = { encoding: "utf8" } as const;
 
-const FS_WRITE_OPTION: any = {encoding: "utf8"};
 enum Prefix {
 	Proj,
 	Bone,
@@ -37,76 +107,63 @@ enum Prefix {
 	Effect
 }
 
-let vlog: U.Logger = undefined;
+let vlog: U.Logger;
 
-export function convert(options: Options): void {
-	options = completeOptions(options);
+/**
+ * コンバータ。
+ *
+ * @param _options コンバートオプション
+ * @returns コンバートのプロミス。
+ */
+export function convert(_options: Options): Promise<any> {
+	const options = completeOptions(_options);
+
 	vlog = new U.Logger(options.verbose);
 
-	vlog.log("option:" + JSON.stringify(options));
+	vlog.log("option:", options);
 
-	const pathToProj = path.dirname(options.projFileName);
-	const proj = new SS.Project();
-	proj.name = path.basename(options.projFileName, ".sspj");
+	if (options.prefixes.length < DEFAULT_PREFIXES.length) {
+		return Promise.reject(`Too few prefixes ${JSON.stringify(options.prefixes)}`);
+	}
 
-	const p: Promise<any> = new Promise<void>( // promise to create output directory
-		(resolve: () => void, reject: (error: any) => void) => {
-			fs.ensureDir(options.outDir, (err: any) => {
-				return err ? reject(err) : resolve();
-			});
-		}
-	);
-	p.then(
-		() => { // promise to load project file
-			return loadAsyncPromise(options.projFileName);
-		},
-		(err: any) => {
-			console.log(err);
-		}
-	)
-		.then(
-			(result: any) => { // promise to load ssae and ssce files
-				const fset = SS.createRelatedFileSetFromSSPJ(result);
-				const allFiles = fset.ssaeFileNames.concat(fset.ssceFileNames, fset.sseeFileNames);
-				return Promise.all(
-					allFiles.map((fname: string) => {
-						console.log("loading... " + fname);
-						return loadAsyncPromise(path.join(pathToProj, fname));
-					})
-				);
-			},
-			(err: any) => {
-				console.log(err);
-			}
-		)
-		.then(
-			(results: any[]) => { // write all files
-				results.map((result: any) => {
-					if ("SpriteStudioAnimePack" in result) { // SSAE
-						SS.loadFromSSAE(proj, result, options);
-					} else if ("SpriteStudioCellMap" in result) {
-						SS.loadFromSSCE(proj, result);
-					} else if ("SpriteStudioEffect" in result) {
-						SS.loadFromSSEE(proj, result);
-					} else {
-						console.log("unknow file type or broken file. skip");
-					}
-				});
-				if (options.bundleAll) {
-					writeAllIntoProjectFile(proj, options.outDir, options.prefixes, options.outputRelatedFileInfo);
+	return Promise.resolve()
+		.then(() => new Promise<void>((resolve, reject) =>
+			fs.ensureDir(options.outDir, err => err ? reject(err) : resolve())
+		))
+		.then(() => U.loadXMLFileAsyncPromise(options.projFileName))
+		.then(result => {
+			const fset = SS.createRelatedFileSetFromSSPJ(result);
+			const allFiles = [...fset.ssaeFileNames, ...fset.ssceFileNames, ...fset.sseeFileNames];
+			const pathToProj = path.dirname(options.projFileName);
+			return Promise.all(
+				allFiles.map(fname => {
+					vlog.log(`Load ${fname}`);
+					return U.loadXMLFileAsyncPromise(path.join(pathToProj, fname));
+				})
+			);
+		})
+		.then(results => {
+			const proj = new SS.Project();
+			proj.name = path.basename(options.projFileName, ".sspj");
+
+			for (const result of results) {
+				if ("SpriteStudioAnimePack" in result) {
+					SS.loadFromSSAE(proj, result, options);
+				} else if ("SpriteStudioCellMap" in result) {
+					SS.loadFromSSCE(proj, result);
+				} else if ("SpriteStudioEffect" in result) {
+					SS.loadFromSSEE(proj, result);
 				} else {
-					writeAll(proj, options.outDir, options.prefixes, options.outputRelatedFileInfo);
+					return Promise.reject(new Error("Unknow file type or broken file"));
 				}
-			},
-			(err: any) => {
-				console.log(err);
 			}
-		)
-		.catch(
-			(err: any) => { // 例外が投げられた時は全てここに到達する
-				console.log(err.stack);
+
+			if (options.bundleAll) {
+				writeAllIntoProjectFile(proj, options.outDir, options.prefixes, options.outputRelatedFileInfo, options.porter);
+			} else {
+				writeAll(proj, options.outDir, options.prefixes, options.outputRelatedFileInfo, options.porter);
 			}
-		);
+		});
 }
 
 function completeOptions(opts: Options): Required<Options> {
@@ -115,8 +172,13 @@ function completeOptions(opts: Options): Required<Options> {
 		outDir: opts.outDir,
 		addPrefix: !!opts.addPrefix,
 		verbose: !!opts.verbose,
-		prefixes: Array.isArray(opts.prefixes) ? opts.prefixes : opts.addPrefix ? DEFAULT_PREFIXES : ["", "", "", ""],
 		bundleAll: !!opts.bundleAll,
+		prefixes: Array.isArray(opts.prefixes)
+			? opts.prefixes
+			: opts.addPrefix
+				? DEFAULT_PREFIXES
+				: DEFAULT_PREFIXES.map(_p => ""),
+		porter: opts.porter ?? "none",
 
 		// SS.LoadFromSSAEOptionObject
 		asaanLongName: !!opts.asaanLongName,
@@ -125,89 +187,175 @@ function completeOptions(opts: Options): Required<Options> {
 		outputUserData: !!opts.outputUserData,
 		outputComboInfo: !!opts.outputComboInfo,
 		outputRelatedFileInfo: !!opts.outputRelatedFileInfo,
-		outputLayoutSize: !!opts.outputLayoutSize
+		outputLayoutSize: !!opts.outputLayoutSize,
+		ignoreUnknownAttribute: !!opts.ignoreUnknownAttribute,
 	};
 }
 
-function loadAsyncPromise(fname: string): Promise<any> {
-	return new Promise<any>(
-		(resolve: (result: any) => void, reject: (error: any) => void) => {
-			U.loadXmlAsJsAsync(fname, (err: any, result: any) => {
-				if (! err) {
-					resolve(result);
-				} else {
-					reject(err);
-				}
-			});
-		}
-	);
-};
+function writeObject(obj: any, name: string, ext: string, outDir: string, version: string, prefix: string): string {
+	const json = JSON.stringify(new ContainerV2(version, obj));
+	const fileName = prefix + name + ext;
+	const fullPath = path.join(outDir, fileName);
+	fs.writeFileSync(fullPath, json, FS_WRITE_OPTION);
+	vlog.log(`Write ${fullPath}`);
+	return fileName;
+}
 
 function writeNamedObjects<T extends { name: string }>(objs: T[], ext: string, outDir: string, version: string, prefix: string): string[] {
 	const fileNames: string[] = [];
-	objs.forEach((obj: T): void => {
-		const json: string = JSON.stringify(new ContainerV2(version, obj));
-		const fileName = prefix + obj.name + ext;
-		const fullPath = path.join(outDir, fileName);
-		fs.writeFileSync(fullPath, json, FS_WRITE_OPTION);
-		vlog.log("write " + fullPath);
+	objs.forEach(obj => {
+		const fileName = writeObject(obj, obj.name, ext, outDir, version, prefix);
 		fileNames.push(fileName);
 	});
 	return fileNames;
 }
 
-function addNamedObjectsToContents<T extends { name: string }>(contents: Content<T>[], objs: T[], type: ContentType): void {
-	objs.forEach((obj: T): void => {
-		contents.push({
-			type,
-			name: obj.name,
-			data: obj
-		});
-	});
-}
+function assertDeepEqual(a: any, b: any): void {
+	const result = U.deepEqual(a, b);
 
-export class RelatedFileInfo {
-	boneSetFileNames: string[];
-	skinFileNames: string[];
-	animationFileNames: string[];
-	effectFileNames: string[];
-	imageFileNames: string[];
-
-	constructor(imageFileNames: string[], contents: any) {
-		this.boneSetFileNames = contents.boneSetFileNames;
-		this.skinFileNames = contents.skinFileNames;
-		this.animationFileNames = contents.animationFileNames;
-		this.effectFileNames = contents.effectFileNames;
-		this.imageFileNames = imageFileNames;
+	if (result !== true) {
+		throw new Error(`DeepEqual failed: ${result}`);
 	}
 }
 
-function writeAll(proj: SS.Project, outDir: string, prefixes: string[], outputRelatedFileInfo: boolean): void {
-	const version = FILEFORMAT_VERSION_V2;
-	const boneSetFileNames = writeNamedObjects<BoneSet>(proj.boneSets, ".asabn", outDir, version, prefixes[Prefix.Bone]);
-	const skinFileNames = writeNamedObjects<Skin>(proj.skins, ".asask", outDir, version, prefixes[Prefix.Skin]);
-	const animFileNames = writeNamedObjects<AnimeParams.Animation>(
-		proj.animations, ".asaan", outDir, version, prefixes[Prefix.Anim]);
-	const effectFileNames = writeNamedObjects<any>(proj.effects, ".asaef", outDir, version, prefixes[Prefix.Effect]);
-	const contents: any = {
-		boneSetFileNames: boneSetFileNames,
-		skinFileNames: skinFileNames,
-		animationFileNames: animFileNames,
-		effectFileNames: effectFileNames,
-		userData: proj.userData
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function verifyPorter(
+	proj: SS.Project,
+	schema: aop.AOPSchema,
+	boneSets: NamedData<any[]>[],
+	skins: NamedData<any[]>[],
+	animations: NamedData<any[]>[],
+	effects: NamedData<any[]>[]
+): void {
+	const importer = new aop.AOPImporter(schema);
+
+	const deserializedBoneSets = boneSets.map(boneSet => importer.importBoneSet(boneSet.data));
+	assertDeepEqual(proj.boneSets, deserializedBoneSets);
+
+	const deserializedSkins = skins.map(skin => importer.importSkin(skin.data));
+	assertDeepEqual(proj.skins, deserializedSkins);
+
+	const deserializedAnimations = animations.map(animation => importer.importAnimation(animation.data));
+	assertDeepEqual(proj.animations, deserializedAnimations);
+
+	const deserializedEffects = effects.map(effect => importer.importEffect(effect.data));
+	assertDeepEqual(proj.effects, deserializedEffects);
+}
+
+function writeAllPorterNone(proj: SS.Project, outDir: string, prefixes: string[], version: string): ProjectV2 {
+	const boneSetFileNames = writeNamedObjects(proj.boneSets, ".asabn", outDir, version, prefixes[Prefix.Bone]);
+	const skinFileNames = writeNamedObjects(proj.skins, ".asask", outDir, version, prefixes[Prefix.Skin]);
+	const animationFileNames = writeNamedObjects(proj.animations, ".asaan", outDir, version, prefixes[Prefix.Anim]);
+	const effectFileNames = writeNamedObjects(proj.effects, ".asaef", outDir, version, prefixes[Prefix.Effect]);
+
+	return {
+		boneSetFileNames,
+		skinFileNames,
+		animationFileNames,
+		effectFileNames,
+		userData: proj.userData,
 	};
+}
+
+function writeAllPorterAOP(proj: SS.Project, outDir: string, prefixes: string[], version: string): ProjectV2 {
+	const exporter = new aop.AOPExporter();
+
+	const compactAnimations = proj.animations.map(anim => {
+		return {
+			name: anim.name,
+			data: exporter.exportAnimation(anim)
+		};
+	});
+
+	const compactBoneSets = proj.boneSets.map(boneSet => {
+		return {
+			name: boneSet.name,
+			data: exporter.exportBoneSet(boneSet)
+		};
+	});
+
+	const compactSkins = proj.skins.map(skin => {
+		return {
+			name: skin.name,
+			data: exporter.exportSkin(skin)
+		};
+	});
+
+	const compactEffects = proj.effects.map(effect => {
+		return {
+			name: effect.name,
+			data: exporter.exportEffect(effect)
+		};
+	});
+
+	// verifyPorter(proj, exporter.getSchema(), compactBoneSets, compactSkins, compactAnimations, compactEffects);
+
+	const boneSetFileNames = compactBoneSets.map(boneSet =>
+		writeObject(boneSet.data, boneSet.name, ".asabn", outDir, version, prefixes[Prefix.Bone])
+	);
+
+	const skinFileNames = compactSkins.map(skin =>
+		writeObject(skin.data, skin.name, ".asask", outDir, version, prefixes[Prefix.Skin])
+	);
+
+	const animationFileNames = compactAnimations.map(anim =>
+		writeObject(anim.data, anim.name, ".asaan", outDir, version, prefixes[Prefix.Anim])
+	);
+
+	const effectFileNames = compactEffects.map(effect =>
+		writeObject(effect.data, effect.name, ".asaef", outDir, version, prefixes[Prefix.Effect])
+	);
+
+	const schema = exporter.getSchema();
+
+	return {
+		boneSetFileNames,
+		skinFileNames,
+		animationFileNames,
+		effectFileNames,
+		userData: proj.userData,
+		schema
+	};
+}
+
+/**
+ * プロジェクトファイルおよびその他関連ファイルをV2形式で出力する。
+ *
+ * @param proj
+ * @param outDir
+ * @param prefixes
+ * @param outputRelatedFileInfo
+ */
+function writeAll(proj: SS.Project, outDir: string, prefixes: string[], outputRelatedFileInfo: boolean, porter: PorterType): void {
+	const version = FILEFORMAT_VERSION_V2;
+
+	const projectV2 = porter === "none"
+		? writeAllPorterNone(proj, outDir, prefixes, version)
+		: porter === "aop"
+			? writeAllPorterAOP(proj, outDir, prefixes, version)
+			: null;
+
+	if (projectV2 == null) {
+		throw new Error(`Unknown porter type: ${porter}`);
+	}
 
 	if (outputRelatedFileInfo) {
-		if (! contents.userData) {
-			contents.userData = {};
-		}
-		// ユーザデータにcontentsと同じものを格納している。
-		// asaファイル群のデータフォーマットは非公開としている。そのため
-		// 内容が重複するがuserDataに格納しなおし、こちらを公開する。
-		contents.userData.relatedFileInfo = new RelatedFileInfo(proj.imageFileNames, contents);
+		const userData = projectV2.userData ?? {};
+		const relatedFileInfo: RelatedFileInfo = {
+			boneSetFileNames: projectV2.boneSetFileNames,
+			skinFileNames: projectV2.skinFileNames,
+			animationFileNames: projectV2.animationFileNames,
+			effectFileNames: projectV2.effectFileNames,
+			imageFileNames: proj.imageFileNames,
+		};
+		projectV2.userData = {
+			...userData,
+			relatedFileInfo
+		};
 	}
 
-	const con = new ContainerV2(version, contents);
+	// プロジェクトファイルを出力
+	const con = new ContainerV2(version, projectV2);
 	const json = JSON.stringify(con);
 	const pjFname = path.join(outDir, prefixes[Prefix.Proj] + proj.name + ".asapj");
 	fs.writeFileSync(pjFname, json, FS_WRITE_OPTION);
@@ -215,23 +363,113 @@ function writeAll(proj: SS.Project, outDir: string, prefixes: string[], outputRe
 	vlog.log("write " + pjFname);
 }
 
-function writeAllIntoProjectFile(proj: SS.Project, outDir: string, prefixes: string[], outputRelatedFileInfo: boolean): void {
+function createContentsV3PorterNone(proj: SS.Project): Content<any>[] {
+	const boneSetContents = proj.boneSets.map(boneSet =>
+		new Content("bone", boneSet.name, boneSet)
+	);
+	const skinContents = proj.skins.map(skin =>
+		new Content("skin", skin.name, skin)
+	);
+	const animationContents = proj.animations.map(animation =>
+		new Content("animation", animation.name, animation)
+	);
+	const effectContents = proj.effects.map(effect =>
+		new Content("effect", effect.name, effect)
+	);
+
+	const projectContent = new Content<ProjectV3>("project", proj.name, {
+		userData: proj.userData,
+	});
+
+	const contents = [
+		projectContent,
+		...boneSetContents,
+		...skinContents,
+		...animationContents,
+		...effectContents,
+	];
+
+	return contents;
+}
+
+function createContentsV3PorterAOP(proj: SS.Project): Content<any>[] {
+	const exporter = new aop.AOPExporter();
+
+	const boneSetContents = proj.boneSets.map(boneSet =>
+		new Content("bone", boneSet.name, exporter.exportBoneSet(boneSet))
+	);
+	const skinContents = proj.skins.map(skin =>
+		new Content("skin", skin.name, exporter.exportSkin(skin))
+	);
+	const animationContents = proj.animations.map(anim =>
+		new Content("animation", anim.name, exporter.exportAnimation(anim))
+	);
+	const effectContents = proj.effects.map(effect =>
+		new Content("effect", effect.name, exporter.exportEffect(effect))
+	);
+
+	const projectContent = new Content<ProjectV3>("project", proj.name, {
+		userData: proj.userData,
+		schema: exporter.getSchema(),
+	});
+
+	const contents = [
+		projectContent,
+		...boneSetContents,
+		...skinContents,
+		...animationContents,
+		...effectContents,
+	];
+
+	return contents;
+}
+
+/**
+ * プロジェクトファイルおよびその他関連ファイルをV3形式で出力する。
+ *
+ * @param proj
+ * @param outDir
+ * @param prefixes
+ * @param outputRelatedFileInfo
+ */
+function writeAllIntoProjectFile(
+	proj: SS.Project,
+	outDir: string,
+	prefixes: string[],
+	outputRelatedFileInfo: boolean,
+	porter: PorterType
+): void {
 	const version = FILEFORMAT_VERSION;
-	const contents: Content<any>[] = [];
 
-	const project: Content<any> = new Content("project", proj.name, { userData: proj.userData });
-	if (outputRelatedFileInfo) {
-		// ユーザデータにcontentsと同じものを格納している。
-		// asaファイル群のデータフォーマットは非公開としている。そのため
-		// 内容が重複するがuserDataに格納しなおし、こちらを公開する。
-		project.data.userData.relatedFileInfo = new RelatedFileInfo(proj.imageFileNames, contents);
+	const contents = porter === "none"
+		? createContentsV3PorterNone(proj)
+		: porter === "aop"
+			? createContentsV3PorterAOP(proj)
+			: null;
+
+	if (contents == null) {
+		throw new Error(`Unknown porter: ${porter}`);
 	}
-	contents.push(project);
 
-	addNamedObjectsToContents(contents, proj.boneSets, "bone");
-	addNamedObjectsToContents(contents, proj.skins, "skin");
-	addNamedObjectsToContents(contents, proj.animations, "animation");
-	addNamedObjectsToContents(contents, proj.effects, "effect");
+	if (outputRelatedFileInfo) {
+		const idx = contents.findIndex(content => content.type === "project");
+		if (idx === -1) {
+			throw new Error("Project not found.");
+		}
+		const projectV3: ProjectV3 = contents[idx].data;
+		const relatedFileInfo: RelatedFileInfo = {
+			boneSetFileNames: [],
+			skinFileNames: [],
+			animationFileNames: [],
+			effectFileNames: [],
+			imageFileNames: proj.imageFileNames,
+		};
+		const userData = projectV3.userData ?? {};
+		projectV3.userData = {
+			...userData,
+			relatedFileInfo
+		};
+	}
 
 	const container = new ContainerV3(version, "bundle", contents);
 	const json = JSON.stringify(container);

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -167,17 +167,28 @@ export function convert(_options: Options): Promise<any> {
 }
 
 function completeOptions(opts: Options): Required<Options> {
+	let prefixes: string[];
+
+	if (Array.isArray(opts.prefixes)) {
+		prefixes = [];
+		for (let i = 0; i < DEFAULT_PREFIXES.length; i++) {
+			prefixes.push(opts.prefixes[i] ?? DEFAULT_PREFIXES[i]);
+		}
+	} else {
+		prefixes = opts.addPrefix
+			? DEFAULT_PREFIXES
+			: DEFAULT_PREFIXES.map(_p => "");
+	}
+
+	console.log(prefixes);
+
 	return {
 		projFileName: opts.projFileName,
 		outDir: opts.outDir,
 		addPrefix: !!opts.addPrefix,
 		verbose: !!opts.verbose,
 		bundleAll: !!opts.bundleAll,
-		prefixes: Array.isArray(opts.prefixes)
-			? opts.prefixes
-			: opts.addPrefix
-				? DEFAULT_PREFIXES
-				: DEFAULT_PREFIXES.map(_p => ""),
+		prefixes,
 		porter: opts.porter ?? "none",
 
 		// SS.LoadFromSSAEOptionObject

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -10,7 +10,7 @@ import {
 	Content,
 	ProjectV2,
 	ProjectV3,
-	aop,
+	aop
 } from "@akashic-extension/akashic-animation";
 /* eslint import/order: 2 */
 import SS = require("./SpriteStudio");
@@ -235,13 +235,19 @@ function assertDeepEqual(a: any, b: any): void {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function verifyPorter(
 	proj: SS.Project,
-	schema: aop.AOPSchema,
+	schema: aop.ArrayOrientedPorterSchema,
 	boneSets: NamedData<any[]>[],
 	skins: NamedData<any[]>[],
 	animations: NamedData<any[]>[],
 	effects: NamedData<any[]>[]
 ): void {
-	const importer = new aop.AOPImporter(schema);
+	const importer = new aop.ArrayOrientedImporter();
+
+	if (!importer.validateSchema(schema)) {
+		throw new Error(`Invalid schema: ${schema}`);
+	}
+
+	importer.setSchema(schema);
 
 	const deserializedBoneSets = boneSets.map(boneSet => importer.importBoneSet(boneSet.data));
 	assertDeepEqual(proj.boneSets, deserializedBoneSets);
@@ -272,7 +278,7 @@ function writeAllPorterNone(proj: SS.Project, outDir: string, prefixes: string[]
 }
 
 function writeAllPorterAOP(proj: SS.Project, outDir: string, prefixes: string[], version: string): ProjectV2 {
-	const exporter = new aop.AOPExporter();
+	const exporter = new aop.ArrayOrientedExporter();
 
 	const compactAnimations = proj.animations.map(anim => {
 		return {
@@ -407,7 +413,7 @@ function createContentsV3PorterNone(proj: SS.Project): Content<any>[] {
 }
 
 function createContentsV3PorterAOP(proj: SS.Project): Content<any>[] {
-	const exporter = new aop.AOPExporter();
+	const exporter = new aop.ArrayOrientedExporter();
 
 	const boneSetContents = proj.boneSets.map(boneSet =>
 		new Content("bone", boneSet.name, exporter.exportBoneSet(boneSet))
@@ -422,7 +428,7 @@ function createContentsV3PorterAOP(proj: SS.Project): Content<any>[] {
 		new Content("effect", effect.name, exporter.exportEffect(effect))
 	);
 
-	const projectContent = new Content<ProjectV3>("project", proj.name, {
+	const projectContent = new Content("project", proj.name, {
 		userData: proj.userData,
 		schema: exporter.getSchema(),
 	});

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -480,9 +480,8 @@ function writeAllIntoProjectFile(
 			effectFileNames: [],
 			imageFileNames: proj.imageFileNames,
 		};
-		const userData = projectV3.userData ?? {};
 		projectV3.userData = {
-			...userData,
+			...projectV3.userData,
 			relatedFileInfo
 		};
 	}

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -354,7 +354,6 @@ function writeAll(proj: SS.Project, outDir: string, prefixes: string[], outputRe
 	}
 
 	if (outputRelatedFileInfo) {
-		const userData = projectV2.userData ?? {};
 		const relatedFileInfo: RelatedFileInfo = {
 			boneSetFileNames: projectV2.boneSetFileNames,
 			skinFileNames: projectV2.skinFileNames,
@@ -362,6 +361,7 @@ function writeAll(proj: SS.Project, outDir: string, prefixes: string[], outputRe
 			effectFileNames: projectV2.effectFileNames,
 			imageFileNames: proj.imageFileNames,
 		};
+		const userData = projectV2.userData ?? {};
 		projectV2.userData = {
 			...userData,
 			relatedFileInfo

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,11 @@
     "noImplicitAny": true,
     "module": "commonjs",
     "outDir": "./lib",
+    "allowUmdGlobalAccess": true,
     "declaration": true
   },
   "files": [
-    "./node_modules/@akashic/akashic-engine/lib/main.d.ts",
+    "./node_modules/@akashic/akashic-engine/index.runtime.d.ts",
     "./node_modules/@akashic-extension/akashic-animation/lib/index.d.ts",
     "./src/cli.ts",
     "./src/index.ts"


### PR DESCRIPTION
[akashic-animation のPR](https://github.com/akashic-games/akashic-animation/pull/144) で提供される ArrayOrientedPorter を利用できるようにします。

合わせて以下の機能を追加します。

1. Akashic Animation で利用できない attribute を利用しているアニメーションをコンバートする時、エラーにせず無視するオプションの追加
2. `-P` オプションで与えるプリフィックスの数が足りない時、エラーにせず、デフォルトプリフィックスで補完するように変更

TODO:
- [x] [akashic-animation のPR](https://github.com/akashic-games/akashic-animation/pull/144) が publish されたらdependencyを更新する 2585858
- [x] バージョンを 2.9.0 に上げる 8755ab8